### PR TITLE
Update to handle hapi 18

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -84,7 +84,7 @@ internals.utility = {
 
         return {
             fallback: message,
-            text: `*${event.method.toUpperCase()}* ${event.url.path}`,
+            text: `*${event.method.toUpperCase()}* ${event.url.pathname}`,
             color: 'danger',
             fields: [
                 {

--- a/test/index.js
+++ b/test/index.js
@@ -446,7 +446,7 @@ describe('events', () => {
                 pretext: '`error` event from *localhost* at ' + timestamp,
                 'mrkdwn_in': ['pretext','text','fields'],
                 fallback: 'Error: Something bad had happened',
-                text: '*GET* /search?name=diego',
+                text: '*GET* /search',
                 color: 'danger',
                 fields:[{
                     title: 'Error',


### PR DESCRIPTION
Fixes #22 

Since hapi 18 removes `event.url.path` from the event surfaced to good, have to use `event.url.pathname` in its place. Exposing the query string via slack can be a security/privacy concern, so it's safer to just go with the path name.